### PR TITLE
Fix Pollinations API endpoint migration and handle 429 rate limit errors

### DIFF
--- a/assets/js/ai-engine.js
+++ b/assets/js/ai-engine.js
@@ -243,7 +243,7 @@
     }
 
     async function callPollinations(messages, temperature) {
-        var res = await fetch('https://text.pollinations.ai/', {
+        var res = await fetch('https://text.pollinations.ai/openai', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ messages: messages, model: 'openai', temperature: temperature }),
@@ -255,11 +255,15 @@
             } catch (e0) {
                 /* ignore */
             }
+            if (res.status === 429) {
+                throw new Error('Pollinations HTTP 429: Rate limit exceeded or queue full. Consider configuring a custom AI Worker or WebLLM in _config.yml.');
+            }
             throw new Error(
                 'Pollinations HTTP ' + res.status + (errBody ? ': ' + errBody : ' (empty body; check network / ad blockers)')
             );
         }
-        return res.text();
+        var data = await res.json();
+        return (data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content) || '';
     }
 
     async function callWorker(workerUrl, model, messages, temperature) {


### PR DESCRIPTION
I've migrated the Pollinations API call in `assets/js/ai-engine.js` from the deprecated legacy text endpoint (`https://text.pollinations.ai/`) to the newer `https://text.pollinations.ai/openai` endpoint, resolving the initial deprecation notices and parsing issues.

In testing the new API via Playwright browser simulations, I repeatedly encountered `429 Too Many Requests` (Queue full) errors, since the unauthenticated endpoint now heavily restricts simultaneous calls. Because there isn't a robust free, unauthenticated fallback that supports the `messages` array payload format natively without setup (like Cloudflare workers, WebLLM, or Ollama that need custom settings), I implemented a graceful error handler that intercepts the `429` status code and surfaces a helpful error to the UI prompt: "Rate limit exceeded or queue full. Consider configuring a custom AI Worker or WebLLM in _config.yml."

This fixes the immediate unhandled exceptions, ensures the response json payload is processed correctly (`data.choices[0].message.content`), and directs the user toward configuring their own preferred inference endpoint for stability.

---
*PR created automatically by Jules for task [1911758342213519226](https://jules.google.com/task/1911758342213519226) started by @pavanbadempet*