### PR TITLE
🧹 Remove console.log from production code in assets/js/main.js

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -687,7 +687,6 @@
 				$btn.prop('disabled', false);
 			},
 			error: function (err) {
-				console.log('Form submission error:', err);
 				alert('Sorry, there was an error sending your message. Please try again or email me directly.');
 				if (originalText) $btn.find('.lnk').text(originalText);
 				$btn.prop('disabled', false);


### PR DESCRIPTION
* 🎯 **What:** Removed debugging `console.log` from the form submission error handler in `assets/js/main.js`.
* 💡 **Why:** `console.log` statements used for debugging should not be left in production code to avoid cluttering the browser console.
* ✅ **Verification:** Verified by building the project using `bundle exec jekyll build` and checking that no other functionality was broken.
* ✨ **Result:** Improved code cleanliness without changing the application's behavior.

---
*PR created automatically by Jules for task [8423019466918864031](https://jules.google.com/task/8423019466918864031) started by @pavanbadempet*