### PR TITLE
⚡ Optimize window resize listener with debounce

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -572,25 +572,27 @@
 	/*
 		Resize
 	*/
+	var resizeTimer;
 	$(window).resize(function () {
+		clearTimeout(resizeTimer);
+		resizeTimer = setTimeout(function() {
+			/* Set full height in blocks */
+			var width = $(window).width();
+			var height = $(window).height();
 
-		/* Set full height in blocks */
-		var width = $(window).width();
-		var height = $(window).height();
-
-		/* Set full height in started blocks */
-		$('.section.started').not('.section-title').css({ 'height': height });
-		if (width < 783) {
+			/* Set full height in started blocks */
 			$('.section.started').not('.section-title').css({ 'height': height });
-		}
+			if (width < 783) {
+				$('.section.started').not('.section-title').css({ 'height': height });
+			}
 
-		/* Dotted skills line on resize */
-		var skills_dotted = $('.skills-list.dotted .progress');
-		var skills_dotted_w = skills_dotted.width();
-		if (skills_dotted.length) {
-			skills_dotted.find('.percentage .da').css({ 'width': skills_dotted_w + 1 });
-		}
-
+			/* Dotted skills line on resize */
+			var skills_dotted = $('.skills-list.dotted .progress');
+			var skills_dotted_w = skills_dotted.width();
+			if (skills_dotted.length) {
+				skills_dotted.find('.percentage .da').css({ 'width': skills_dotted_w + 1 });
+			}
+		}, 250);
 	});
 
 	/*


### PR DESCRIPTION
💡 **What:** Added a 250ms debounce mechanism using `setTimeout` and `clearTimeout` to the `$(window).resize()` event listener.

🎯 **Why:** To prevent layout and styling recalculations from continuously firing during window resize actions. Debouncing significantly reduces the load and improves application efficiency by triggering updates only after the user stops resizing for 250 milliseconds.

📊 **Measured Improvement:** We were unable to show a meaningful performance improvement benchmark since there is no existing benchmark suite or testing framework to measure resize event loops in this Jekyll portfolio site. However, debouncing is a standard frontend performance enhancement. This reduces continuous DOM reflows down to one reflow that executes 250ms after the resize finishes, drastically reducing CPU utilization and potential UI stuttering.

---
*PR created automatically by Jules for task [9214912188105604692](https://jules.google.com/task/9214912188105604692) started by @pavanbadempet*